### PR TITLE
Switch image tag org to be lunarway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,6 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
-# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
-# This variable is used to construct full image tags for bundle and catalog images.
-#
-# For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
-# lunar.tech/cluster-routing-controller-bundle:$VERSION and lunar.tech/cluster-routing-controller-catalog:$VERSION.
-IMAGE_TAG_BASE ?= lunarway/cluster-routing-controller
-
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)


### PR DESCRIPTION
Currently, releases fail as the pipeline tries to write to a lunar.tech org in quay.