### PR TITLE
React to ingress update operations

### DIFF
--- a/apis/networking/v1/ingress_webhook.go
+++ b/apis/networking/v1/ingress_webhook.go
@@ -53,7 +53,8 @@ func (a *IngressAnnotator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	ingresslog.Info("IngressAnnotator found Ingress")
-	if req.Operation != admissionv1.Create {
+	if req.Operation != admissionv1.Create &&
+		req.Operation != admissionv1.Update {
 		return admission.Allowed("not a create operation")
 	}
 


### PR DESCRIPTION
Currently, the webhook will only handle newly created ingresses.

This is not enough as ingress will be updated with the control annotation which should make the webhook set the appropriate annotations before external-dns takes over.

This PR adds the updated operation to its handle