### PR TITLE
Exit loops early when ingresses are not controlled

### DIFF
--- a/apis/networking/v1/ingress_webhook.go
+++ b/apis/networking/v1/ingress_webhook.go
@@ -64,7 +64,7 @@ func (a *IngressAnnotator) Handle(ctx context.Context, req admission.Request) ad
 	}
 
 	if !shouldUpdateIngress {
-		return admission.Allowed("nothing to add")
+		return admission.Allowed("ingress is not controlled")
 	}
 
 	operator.SetIngressAnnotations(ctx, ingress, routingWeight)

--- a/controllers/networking/ingress_controller.go
+++ b/controllers/networking/ingress_controller.go
@@ -68,6 +68,11 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return reconcile.Result{}, err
 	}
 
+	if !updateIngress {
+		logger.Info("Ingress is not controlled. skipping.")
+		return ctrl.Result{}, nil
+	}
+
 	operator.SetIngressAnnotations(ctx, ingress, routingWeight)
 	err = operator.UpdateIngress(ctx, r.Client, !updateIngress, ingress)
 	if err != nil {

--- a/internal/operator/functions.go
+++ b/internal/operator/functions.go
@@ -70,7 +70,6 @@ func DoesIngressNeedsUpdating(ctx context.Context, client client.Client, cluster
 	logger := log.FromContext(ctx)
 
 	if !IsIngressControlled(*ingress) {
-		logger.Info("Ingress is not controlled. skipping.")
 		return false, v1alpha1.RoutingWeight{}, nil
 	}
 


### PR DESCRIPTION
We see logs that say that we skip and then print dry-run:

```
2021-09-23 13:00:40.159 | 2021-09-23T11:00:40.159Z	INFO	controller-runtime.manager.controller.ingress	dryRun=true Dryrun of change. Doing nothing	{"reconciler group": "networking.k8s.io", "reconciler kind": "Ingress", "name": "grafana", "namespace": "monitoring"}
-- | --
  | 2021-09-23 13:00:40.159 | 2021-09-23T11:00:40.159Z	INFO	controller-runtime.manager.controller.ingress	dryRun=true Updating ingress object in api server	{"reconciler group": "networking.k8s.io", "reconciler kind": "Ingress", "name": "grafana", "namespace": "monitoring"}
  | 2021-09-23 13:00:40.159 | 2021-09-23T11:00:40.159Z	INFO	controller-runtime.manager.controller.ingress	Ingress is not controlled. skipping.	{"reconciler group": "networking.k8s.io", "reconciler kind": "Ingress", "name": "grafana", "namespace": "monitoring"}
```

This change removes the dry run logs when ingresses are not controlled.

