### PR TITLE
Add go-cache and trigger Docker release from published Release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,27 @@
 name: "CI"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
 
 jobs:
   basic-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
           go-version: "1.17"
+
+      - name: Cache Go modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: "Formatting check"
         run: make fmt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,18 @@
 name: "Release"
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: github.event.release.target_commitish == 'master'
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
+          go-version: "1.17.7"
 
       - name: Set tag in environment
         run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV # extracts the tag name from refs/tags/v1.2.3
@@ -21,9 +22,9 @@ jobs:
 
       - name: "Docker login to Quay.io"
         env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD quay.io
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+        run: docker login -u $QUAY_USERNAME -p $QUAY_PASSWORD quay.io
 
       - name: "Push image"
         run: make docker-push TAG=$RELEASE_VERSION


### PR DESCRIPTION
This change adds a release trigger to only run on published Github releases.

The CI workflow also now uses a go-cache