### PR TITLE
wrapped github statement

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    if: github.event.release.target_commitish == 'master'
+    if: ${{ github.event.release.target_commitish }} == 'master'
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
action job was not excecuted after release.
Assumes this is due to variable wrapping.