### PR TITLE
chore: Migrate squad from Odyssey to Esa

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-odyssey
+* @lunarway/squad-esa

--- a/shuttle.yaml
+++ b/shuttle.yaml
@@ -1,5 +1,5 @@
 plan: false
 vars:
   service: cluster-routing-controller
-  squad: odyssey
+  squad: esa
   domain: multi-cloud-container-runtime


### PR DESCRIPTION
This batch change migrates repository ownership from squad-odyssey to squad-esa.

The following changes have been applied:
- `shuttle.yaml` squad updated to `esa`.
- `CODEOWNERS` updated to reference `@lunarway/squad-esa`.

**Next Steps:**
- Please ensure that the `squad-esa` team has the appropriate permissions on this repository. (Will be done using a script Tinus made)

[_Created by Sourcegraph batch change `jan/odyssey-to-esa`._](https://lunar.sourcegraph.com/users/jan/batch-changes/odyssey-to-esa)